### PR TITLE
Add Ruby 4.0 to precompiled gem matrix; drop Ruby 2.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         id: cross-gem
         with:
           platform: ${{ matrix.platform }}
-          ruby-versions: "2.7,3.3,3.4"
+          ruby-versions: "3.3,3.4,4.0"
           cache-version: v2
 
       - uses: actions/upload-artifact@v6
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.4"]
+        ruby: ["3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/wreq-rb.gemspec
+++ b/wreq-rb.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
                         "cookie handling, proxy support, and redirect policies."
   spec.homepage      = "https://github.com/serpapi/wreq-rb"
   spec.license       = "Apache-2.0"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.files = Dir[
     "exe/*",
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/wreq_rb/extconf.rb"]
 
-  # 0.9.123 is the last version that uses rake-compiler-dock 1.10.0 (Ruby 2.7 support)
-  spec.add_dependency "rb_sys", "0.9.123"
+  # 0.9.124+ uses rake-compiler-dock 1.11.0, which adds Ruby 4.0 cross-compilation
+  # support and drops Ruby 2.7. Bumping to 0.9.126 (latest patch).
+  spec.add_dependency "rb_sys", "0.9.126"
 end


### PR DESCRIPTION
rake-compiler-dock 1.11.0 (used by rb_sys 0.9.124+) adds Ruby 4.0 cross-compilation but removes Ruby 2.7 in the same image. Ruby 2.7 reached EOL in 2023-03, so bumping rb_sys to 0.9.126 and shifting the precompiled ABI matrix from "2.7,3.3,3.4" to "3.3,3.4,4.0".

Without this change, Ruby 4.0 users fall back to a source build (BoringSSL + Rust, ~10 minutes) and require rustc >= 1.87.